### PR TITLE
AA-417: Fix ignored paymaster revert

### DIFF
--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -490,7 +490,7 @@ func prepareAccountExecutionMessage(baseTx *types.Transaction, config *params.Ch
 		GasPrice:          tx.GasFeeCap,
 		GasFeeCap:         tx.GasFeeCap,
 		GasTipCap:         tx.GasTipCap,
-		Data:              tx.Data,
+		Data:              tx.ExecutionData,
 		AccessList:        nil,
 		SkipAccountChecks: true,
 		IsRip7560Frame:    true,

--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -377,7 +377,7 @@ func ApplyRip7560ValidationPhases(
 	return vpr, nil
 }
 
-func applyPaymasterValidationFrame(epc *EntryPointCall, tx *types.Transaction, chainConfig *params.ChainConfig, signingHash common.Hash, evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *types.Header) ([]byte, uint64, uint64, uint64, *ValidationPhaseError) {
+func applyPaymasterValidationFrame(epc *EntryPointCall, tx *types.Transaction, chainConfig *params.ChainConfig, signingHash common.Hash, evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *types.Header) ([]byte, uint64, uint64, uint64, error) {
 	/*** Paymaster Validation Frame ***/
 	aatx := tx.Rip7560TransactionData()
 	var pmValidationUsedGas uint64

--- a/core/types/transaction_signing_rip7560.go
+++ b/core/types/transaction_signing_rip7560.go
@@ -32,7 +32,6 @@ func (s rip7560Signer) Hash(tx *Transaction) common.Hash {
 			tx.GasTipCap(),
 			tx.GasFeeCap(),
 			tx.Gas(),
-			//tx.To(),
 			tx.Data(),
 			tx.AccessList(),
 

--- a/core/types/tx_rip7560.go
+++ b/core/types/tx_rip7560.go
@@ -100,7 +100,7 @@ func (tx *Rip7560AccountAbstractionTx) copy() TxData {
 func (tx *Rip7560AccountAbstractionTx) txType() byte           { return Rip7560Type }
 func (tx *Rip7560AccountAbstractionTx) chainID() *big.Int      { return tx.ChainID }
 func (tx *Rip7560AccountAbstractionTx) accessList() AccessList { return tx.AccessList }
-func (tx *Rip7560AccountAbstractionTx) data() []byte           { return tx.ExecutionData }
+func (tx *Rip7560AccountAbstractionTx) data() []byte           { return make([]byte, 0) }
 func (tx *Rip7560AccountAbstractionTx) gas() uint64            { return tx.Gas }
 func (tx *Rip7560AccountAbstractionTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
 func (tx *Rip7560AccountAbstractionTx) gasTipCap() *big.Int    { return tx.GasTipCap }

--- a/core/types/tx_rip7560.go
+++ b/core/types/tx_rip7560.go
@@ -32,12 +32,12 @@ type Rip7560AccountAbstractionTx struct {
 	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
 	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
 	Gas        uint64
-	Data       []byte
 	AccessList AccessList
 
 	// extra fields
 	Sender                      *common.Address
-	Signature                   []byte
+	AuthorizationData           []byte
+	ExecutionData               []byte
 	Paymaster                   *common.Address `rlp:"nil"`
 	PaymasterData               []byte
 	Deployer                    *common.Address `rlp:"nil"`
@@ -51,27 +51,27 @@ type Rip7560AccountAbstractionTx struct {
 	NonceKey *big.Int
 
 	// removed fields
-	To    *common.Address `rlp:"nil"`
-	Value *big.Int
+	//To    *common.Address `rlp:"nil"`
+	//Value *big.Int
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *Rip7560AccountAbstractionTx) copy() TxData {
 	cpy := &Rip7560AccountAbstractionTx{
-		To:       copyAddressPtr(tx.To),
-		Data:     common.CopyBytes(tx.Data),
-		Nonce:    tx.Nonce,
-		NonceKey: new(big.Int),
-		Gas:      tx.Gas,
+		//To:            copyAddressPtr(tx.To),
+		ExecutionData: common.CopyBytes(tx.ExecutionData),
+		Nonce:         tx.Nonce,
+		NonceKey:      new(big.Int),
+		Gas:           tx.Gas,
 		// These are copied below.
 		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasTipCap:  new(big.Int),
-		GasFeeCap:  new(big.Int),
+		//Value:      new(big.Int),
+		ChainID:   new(big.Int),
+		GasTipCap: new(big.Int),
+		GasFeeCap: new(big.Int),
 
 		Sender:                      copyAddressPtr(tx.Sender),
-		Signature:                   common.CopyBytes(tx.Signature),
+		AuthorizationData:           common.CopyBytes(tx.AuthorizationData),
 		Paymaster:                   copyAddressPtr(tx.Paymaster),
 		PaymasterData:               common.CopyBytes(tx.PaymasterData),
 		Deployer:                    copyAddressPtr(tx.Deployer),
@@ -82,9 +82,9 @@ func (tx *Rip7560AccountAbstractionTx) copy() TxData {
 		PostOpGas:                   tx.PostOpGas,
 	}
 	copy(cpy.AccessList, tx.AccessList)
-	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
-	}
+	//if tx.Value != nil {
+	//	cpy.Value.Set(tx.Value)
+	//}
 	if tx.ChainID != nil {
 		cpy.ChainID.Set(tx.ChainID)
 	}
@@ -107,14 +107,14 @@ func (tx *Rip7560AccountAbstractionTx) copy() TxData {
 func (tx *Rip7560AccountAbstractionTx) txType() byte           { return Rip7560Type }
 func (tx *Rip7560AccountAbstractionTx) chainID() *big.Int      { return tx.ChainID }
 func (tx *Rip7560AccountAbstractionTx) accessList() AccessList { return tx.AccessList }
-func (tx *Rip7560AccountAbstractionTx) data() []byte           { return tx.Data }
+func (tx *Rip7560AccountAbstractionTx) data() []byte           { return tx.ExecutionData }
 func (tx *Rip7560AccountAbstractionTx) gas() uint64            { return tx.Gas }
 func (tx *Rip7560AccountAbstractionTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
 func (tx *Rip7560AccountAbstractionTx) gasTipCap() *big.Int    { return tx.GasTipCap }
 func (tx *Rip7560AccountAbstractionTx) gasPrice() *big.Int     { return tx.GasFeeCap }
-func (tx *Rip7560AccountAbstractionTx) value() *big.Int        { return tx.Value }
+func (tx *Rip7560AccountAbstractionTx) value() *big.Int        { return big.NewInt(0) }
 func (tx *Rip7560AccountAbstractionTx) nonce() uint64          { return tx.Nonce }
-func (tx *Rip7560AccountAbstractionTx) to() *common.Address    { return tx.To }
+func (tx *Rip7560AccountAbstractionTx) to() *common.Address    { return &common.Address{} }
 
 // IsRip7712Nonce returns true if the transaction uses an RIP-7712 two-dimensional nonce
 func (tx *Rip7560AccountAbstractionTx) IsRip7712Nonce() bool {
@@ -150,9 +150,9 @@ func (t *Rip7560AccountAbstractionTx) encode(b *bytes.Buffer) error {
 	if tx.Deployer != nil && zeroAddress.Cmp(*tx.Deployer) == 0 {
 		tx.Deployer = nil
 	}
-	if tx.To != nil && zeroAddress.Cmp(*tx.To) == 0 {
-		tx.To = nil
-	}
+	//if tx.To != nil && zeroAddress.Cmp(*tx.To) == 0 {
+	//	tx.To = nil
+	//}
 	return rlp.Encode(b, tx)
 }
 
@@ -229,8 +229,8 @@ func (tx *Rip7560AccountAbstractionTx) AbiEncode() ([]byte, error) {
 		PaymasterData:               tx.PaymasterData,
 		Deployer:                    *deployer,
 		DeployerData:                tx.DeployerData,
-		CallData:                    tx.Data,
-		Signature:                   tx.Signature,
+		CallData:                    tx.ExecutionData,
+		Signature:                   tx.AuthorizationData,
 	}
 	packed, err := args.Pack(&record)
 	return packed, err

--- a/core/types/tx_rip7560.go
+++ b/core/types/tx_rip7560.go
@@ -49,10 +49,6 @@ type Rip7560AccountAbstractionTx struct {
 
 	// RIP-7712 two-dimensional nonce (optional), 192 bits
 	NonceKey *big.Int
-
-	// removed fields
-	//To    *common.Address `rlp:"nil"`
-	//Value *big.Int
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
@@ -82,9 +78,6 @@ func (tx *Rip7560AccountAbstractionTx) copy() TxData {
 		PostOpGas:                   tx.PostOpGas,
 	}
 	copy(cpy.AccessList, tx.AccessList)
-	//if tx.Value != nil {
-	//	cpy.Value.Set(tx.Value)
-	//}
 	if tx.ChainID != nil {
 		cpy.ChainID.Set(tx.ChainID)
 	}
@@ -150,9 +143,6 @@ func (t *Rip7560AccountAbstractionTx) encode(b *bytes.Buffer) error {
 	if tx.Deployer != nil && zeroAddress.Cmp(*tx.Deployer) == 0 {
 		tx.Deployer = nil
 	}
-	//if tx.To != nil && zeroAddress.Cmp(*tx.To) == 0 {
-	//	tx.To = nil
-	//}
 	return rlp.Encode(b, tx)
 }
 
@@ -177,8 +167,8 @@ type Rip7560Transaction struct {
 	PaymasterData               []byte
 	Deployer                    common.Address
 	DeployerData                []byte
-	CallData                    []byte
-	Signature                   []byte
+	ExecutionData               []byte
+	AuthorizationData           []byte
 }
 
 func (tx *Rip7560AccountAbstractionTx) AbiEncode() ([]byte, error) {
@@ -197,8 +187,8 @@ func (tx *Rip7560AccountAbstractionTx) AbiEncode() ([]byte, error) {
 		{Name: "paymasterData", Type: "bytes"},
 		{Name: "deployer", Type: "address"},
 		{Name: "deployerData", Type: "bytes"},
-		{Name: "callData", Type: "bytes"},
-		{Name: "signature", Type: "bytes"},
+		{Name: "executionData", Type: "bytes"},
+		{Name: "authorizationData", Type: "bytes"},
 	})
 
 	args := abi.Arguments{
@@ -229,8 +219,8 @@ func (tx *Rip7560AccountAbstractionTx) AbiEncode() ([]byte, error) {
 		PaymasterData:               tx.PaymasterData,
 		Deployer:                    *deployer,
 		DeployerData:                tx.DeployerData,
-		CallData:                    tx.ExecutionData,
-		Signature:                   tx.AuthorizationData,
+		ExecutionData:               tx.ExecutionData,
+		AuthorizationData:           tx.AuthorizationData,
 	}
 	packed, err := args.Pack(&record)
 	return packed, err

--- a/core/types/tx_rip7560.go
+++ b/core/types/tx_rip7560.go
@@ -107,7 +107,7 @@ func (tx *Rip7560AccountAbstractionTx) gasTipCap() *big.Int    { return tx.GasTi
 func (tx *Rip7560AccountAbstractionTx) gasPrice() *big.Int     { return tx.GasFeeCap }
 func (tx *Rip7560AccountAbstractionTx) value() *big.Int        { return big.NewInt(0) }
 func (tx *Rip7560AccountAbstractionTx) nonce() uint64          { return tx.Nonce }
-func (tx *Rip7560AccountAbstractionTx) to() *common.Address    { return &common.Address{} }
+func (tx *Rip7560AccountAbstractionTx) to() *common.Address    { return nil }
 
 // IsRip7712Nonce returns true if the transaction uses an RIP-7712 two-dimensional nonce
 func (tx *Rip7560AccountAbstractionTx) IsRip7712Nonce() bool {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1352,7 +1352,8 @@ type RPCTransaction struct {
 
 	// Introduced by RIP-7560 Transaction
 	Sender                      *common.Address `json:"sender,omitempty"`
-	Signature                   *hexutil.Bytes  `json:"signature,omitempty"`
+	AuthorizationData           *hexutil.Bytes  `json:"authorizationData,omitempty"`
+	ExecutionData               *hexutil.Bytes  `json:"executionData,omitempty"`
 	Paymaster                   *common.Address `json:"paymaster,omitempty"`
 	PaymasterData               *hexutil.Bytes  `json:"paymasterData,omitempty"`
 	Deployer                    *common.Address `json:"deployer,omitempty"`
@@ -1442,10 +1443,12 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.S = nil
 		result.R = nil
 		result.V = nil
+		result.To = nil
 		result.NonceKey = (*hexutil.Big)(rip7560Tx.NonceKey)
-		result.Input = rip7560Tx.ExecutionData
+		result.Input = make(hexutil.Bytes, 0)
 		result.Sender = rip7560Tx.Sender
-		result.Signature = toBytes(rip7560Tx.AuthorizationData)
+		result.AuthorizationData = toBytes(rip7560Tx.AuthorizationData)
+		result.ExecutionData = toBytes(rip7560Tx.ExecutionData)
 		result.Gas = hexutil.Uint64(tx.Gas())
 		result.Paymaster = rip7560Tx.Paymaster
 		result.PaymasterData = toBytes(rip7560Tx.PaymasterData)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1443,9 +1443,9 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.R = nil
 		result.V = nil
 		result.NonceKey = (*hexutil.Big)(rip7560Tx.NonceKey)
-		result.Input = rip7560Tx.Data
+		result.Input = rip7560Tx.ExecutionData
 		result.Sender = rip7560Tx.Sender
-		result.Signature = toBytes(rip7560Tx.Signature)
+		result.Signature = toBytes(rip7560Tx.AuthorizationData)
 		result.Gas = hexutil.Uint64(tx.Gas())
 		result.Paymaster = rip7560Tx.Paymaster
 		result.PaymasterData = toBytes(rip7560Tx.PaymasterData)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -531,7 +531,7 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 			GasFeeCap: (*big.Int)(args.MaxFeePerGas),
 			GasTipCap: (*big.Int)(args.MaxPriorityFeePerGas),
 			//Value:         (*big.Int)(args.Value),
-			ExecutionData: args.data(),
+			ExecutionData: *args.ExecutionData,
 			AccessList:    al,
 			// RIP-7560 parameters
 			Sender:                      args.Sender,
@@ -545,6 +545,15 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 			PaymasterValidationGasLimit: toUint64(args.PaymasterGas),
 			PostOpGas:                   toUint64(args.PostOpGas),
 		}
+
+		zeroAddress := common.Address{}
+		if aatx.Paymaster != nil && zeroAddress.Cmp(*aatx.Paymaster) == 0 {
+			aatx.Paymaster = nil
+		}
+		if aatx.Deployer != nil && zeroAddress.Cmp(*aatx.Deployer) == 0 {
+			aatx.Deployer = nil
+		}
+
 		data = &aatx
 		hash := types.NewTx(data).Hash()
 		log.Error("RIP-7560 transaction created", "sender", aatx.Sender.Hex(), "hash", hash)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -76,16 +76,17 @@ type TransactionArgs struct {
 	blobSidecarAllowed bool
 
 	// Introduced by RIP-7560 Transaction
-	Sender        *common.Address `json:"sender"`
-	Signature     *hexutil.Bytes
-	Paymaster     *common.Address `json:"paymaster,omitempty"`
-	PaymasterData *hexutil.Bytes  `json:"paymasterData,omitempty"`
-	Deployer      *common.Address `json:"deployer,omitempty"`
-	DeployerData  *hexutil.Bytes  `json:"deployerData,omitempty"`
-	BuilderFee    *hexutil.Big
-	ValidationGas *hexutil.Uint64 `json:"verificationGasLimit"`
-	PaymasterGas  *hexutil.Uint64 `json:"paymasterVerificationGasLimit"`
-	PostOpGas     *hexutil.Uint64 `json:"paymasterPostOpGasLimit"`
+	Sender            *common.Address `json:"sender"`
+	AuthorizationData *hexutil.Bytes  `json:"authorizationData,omitempty"`
+	ExecutionData     *hexutil.Bytes  `json:"executionData,omitempty"`
+	Paymaster         *common.Address `json:"paymaster,omitempty"`
+	PaymasterData     *hexutil.Bytes  `json:"paymasterData,omitempty"`
+	Deployer          *common.Address `json:"deployer,omitempty"`
+	DeployerData      *hexutil.Bytes  `json:"deployerData,omitempty"`
+	BuilderFee        *hexutil.Big    `json:"builderFee,omitempty"`
+	ValidationGas     *hexutil.Uint64 `json:"verificationGasLimit"`
+	PaymasterGas      *hexutil.Uint64 `json:"paymasterVerificationGasLimit"`
+	PostOpGas         *hexutil.Uint64 `json:"paymasterPostOpGasLimit"`
 
 	// Introduced by RIP-7712 Transaction
 	NonceKey *hexutil.Big `json:"nonceKey,omitempty"`
@@ -522,19 +523,19 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 			al = *args.AccessList
 		}
 		aatx := types.Rip7560AccountAbstractionTx{
-			To:         &common.Address{},
-			ChainID:    (*big.Int)(args.ChainID),
-			Gas:        uint64(*args.Gas),
-			NonceKey:   (*big.Int)(args.NonceKey),
-			Nonce:      uint64(*args.Nonce),
-			GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
-			GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
-			Value:      (*big.Int)(args.Value),
-			Data:       args.data(),
-			AccessList: al,
+			//To:            &common.Address{},
+			ChainID:   (*big.Int)(args.ChainID),
+			Gas:       uint64(*args.Gas),
+			NonceKey:  (*big.Int)(args.NonceKey),
+			Nonce:     uint64(*args.Nonce),
+			GasFeeCap: (*big.Int)(args.MaxFeePerGas),
+			GasTipCap: (*big.Int)(args.MaxPriorityFeePerGas),
+			//Value:         (*big.Int)(args.Value),
+			ExecutionData: args.data(),
+			AccessList:    al,
 			// RIP-7560 parameters
 			Sender:                      args.Sender,
-			Signature:                   *args.Signature,
+			AuthorizationData:           *args.AuthorizationData,
 			Paymaster:                   args.Paymaster,
 			PaymasterData:               *args.PaymasterData,
 			Deployer:                    args.Deployer,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -382,11 +382,13 @@ func (miner *Miner) commitRip7560TransactionsBundle(env *environment, txs *types
 	}
 
 	validatedTxs, receipts, _, err := core.HandleRip7560Transactions(txs.Transactions, 0, env.state, &env.coinbase, env.header, env.gasPool, miner.chainConfig, miner.chain, vm.Config{})
-
+	if err != nil {
+		return err
+	}
 	env.txs = append(env.txs, validatedTxs...)
 	env.receipts = append(env.receipts, receipts...)
 	env.tcount += len(validatedTxs)
-	return err
+	return nil
 }
 
 // fillTransactions retrieves the pending transactions from the txpool and fills them

--- a/tests/rip7560/process_test.go
+++ b/tests/rip7560/process_test.go
@@ -45,7 +45,7 @@ func TestProcess1(t *testing.T) {
 			Sender:             &Sender,
 			ValidationGasLimit: uint64(1000000000),
 			GasFeeCap:          big.NewInt(1000000000),
-			Data:               []byte{1, 2, 3},
+			ExecutionData:      []byte{1, 2, 3},
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
Failures in the validation phase can be caused by an on-chain revert or
a non chain related issue.
On-chain reverts may generate an 'error' (i.e. "out of gas") or provide
a ReturnData bytes array.
The new 'ValidationPhaseError' tries to keep this data until it is used.